### PR TITLE
Switch to Docker Hub password to update readme

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -103,7 +103,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
           repository: sketchbench/bullet-${{ matrix.component }}
           short-description: ${{ matrix.description }}
           readme-filepath: ./components/${{ matrix.component }}/README.md


### PR DESCRIPTION
Password is required since Docker Hub does not support tokens to update the Docker Hub readme files:
- https://github.com/peter-evans/dockerhub-description/issues/10
- https://github.com/docker/hub-feedback/issues/1927
- https://github.com/docker/roadmap/issues/115