### PR TITLE
Add support for Bullet DSL in Bullet Spark backend

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -24,6 +24,7 @@ jobs:
               BULLET_EXAMPLES_VERSION=1.0.0
               BULLET_KAFKA_VERSION=1.2.2
               BULLET_SPARK_VERSION=1.0.4
+              BULLET_DSL_VERSION=1.1.6
           - component: ui
             version: "1.1.0"
             latest: true

--- a/components/spark/Dockerfile
+++ b/components/spark/Dockerfile
@@ -3,6 +3,7 @@ FROM docker.io/bitnami/spark:3
 ARG BULLET_EXAMPLES_VERSION=1.0.0
 ARG BULLET_KAFKA_VERSION=1.2.2
 ARG BULLET_SPARK_VERSION=1.0.4
+ARG BULLET_DSL_VERSION=1.1.6
 
 # bullet-spark-example
 RUN mkdir -p /tmp/examples_artifacts && \
@@ -16,3 +17,6 @@ RUN curl --retry 2 -L -s -o /opt/bitnami/spark/jars/bullet-kafka-${BULLET_KAFKA_
 
 # bullet-spark (standalone)
 RUN curl --retry 2 -L -s -o /opt/bitnami/spark/jars/bullet-spark-${BULLET_SPARK_VERSION}-standalone.jar https://search.maven.org/remotecontent?filepath=com/yahoo/bullet/bullet-spark/${BULLET_SPARK_VERSION}/bullet-spark-${BULLET_SPARK_VERSION}-standalone.jar
+
+# bullet-dsl ("normal" jar)
+RUN curl --retry 2 -L -s -o /opt/bitnami/spark/jars/bullet-dsl.jar https://search.maven.org/remotecontent?filepath=com/yahoo/bullet/bullet-dsl/${BULLET_DSL_VERSION}/bullet-dsl-${BULLET_DSL_VERSION}.jar

--- a/components/spark/Dockerfile
+++ b/components/spark/Dockerfile
@@ -13,10 +13,10 @@ RUN mkdir -p /tmp/examples_artifacts && \
     rm -rf /tmp/examples_artifacts*
 
 # bullet-kafka (fat jar)
-RUN curl --retry 2 -L -s -o /opt/bitnami/spark/jars/bullet-kafka-${BULLET_KAFKA_VERSION}-fat.jar https://search.maven.org/remotecontent?filepath=com/yahoo/bullet/bullet-kafka/${BULLET_KAFKA_VERSION}/bullet-kafka-${BULLET_KAFKA_VERSION}-fat.jar
+RUN curl --retry 2 -L -s -o /opt/bitnami/spark/jars/bullet-kafka-fat.jar https://search.maven.org/remotecontent?filepath=com/yahoo/bullet/bullet-kafka/${BULLET_KAFKA_VERSION}/bullet-kafka-${BULLET_KAFKA_VERSION}-fat.jar
 
 # bullet-spark (standalone)
-RUN curl --retry 2 -L -s -o /opt/bitnami/spark/jars/bullet-spark-${BULLET_SPARK_VERSION}-standalone.jar https://search.maven.org/remotecontent?filepath=com/yahoo/bullet/bullet-spark/${BULLET_SPARK_VERSION}/bullet-spark-${BULLET_SPARK_VERSION}-standalone.jar
+RUN curl --retry 2 -L -s -o /opt/bitnami/spark/jars/bullet-spark-standalone.jar https://search.maven.org/remotecontent?filepath=com/yahoo/bullet/bullet-spark/${BULLET_SPARK_VERSION}/bullet-spark-${BULLET_SPARK_VERSION}-standalone.jar
 
 # bullet-dsl ("normal" jar)
 RUN curl --retry 2 -L -s -o /opt/bitnami/spark/jars/bullet-dsl.jar https://search.maven.org/remotecontent?filepath=com/yahoo/bullet/bullet-dsl/${BULLET_DSL_VERSION}/bullet-dsl-${BULLET_DSL_VERSION}.jar


### PR DESCRIPTION
## Changes

- Add support for Bullet DSL in Bullet Spark backend
- Remove version info from jar file names to ease writing of Helm charts